### PR TITLE
Use request.path_info.

### DIFF
--- a/lib/heroku/bouncer/middleware.rb
+++ b/lib/heroku/bouncer/middleware.rb
@@ -138,7 +138,7 @@ private
   end
 
   def auth_request?
-    %w[/auth/heroku/callback /auth/heroku /auth/failure /auth/sso-logout /auth/logout /auth/login].include?(request.path)
+    %w[/auth/heroku/callback /auth/heroku /auth/failure /auth/sso-logout /auth/logout /auth/login].include?(request.path_info)
   end
 
   def session_nonce_mismatch?


### PR DESCRIPTION
This allows use of heroku-bouncer at paths other than `/`, such as in a `map "/foo"` block on a Rack::Builder.