### PR TITLE
Pass bouncer.refresh_token as well as bouncer.token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Based on your choice of the expose options above, the middleware adds
 the following keys to your request environment:
 
 * `bouncer.token`
+* `bouncer.refresh_token`
 * `bouncer.email`
 * `bouncer.user`
 
@@ -161,6 +162,12 @@ apps = heroku.get_apps.body
 
 Keep in mind that this adds substantial security risk to your
 application.
+
+The API token is short-lived, and expires 8 hours after issue. Heroku provides
+a separate `refresh_token` (available as `bouncer.refresh_token`) that can be
+used to fetch fresh API tokens if necessary. See the
+[token refresh documentation](https://devcenter.heroku.com/articles/oauth#token-refresh)
+for details.
 
 ## Logging out
 

--- a/lib/heroku/bouncer/middleware.rb
+++ b/lib/heroku/bouncer/middleware.rb
@@ -82,7 +82,8 @@ class Heroku::Bouncer::Middleware < Sinatra::Base
 
   # callback when successful, time to save data
   get '/auth/heroku/callback' do
-    token = request.env['omniauth.auth']['credentials']['token']
+    token         = request.env['omniauth.auth']['credentials']['token']
+    refresh_token = request.env['omniauth.auth']['credentials']['refresh_token']
     if @expose_email || @expose_user || !@allow_if_user.nil?
       user = fetch_user(token)
       # Wrapping lambda to prevent short-circut proc return
@@ -97,7 +98,10 @@ class Heroku::Bouncer::Middleware < Sinatra::Base
       store_write(:user, true)
     end
     store_write(@session_sync_nonce.to_sym, session_nonce_cookie) if @session_sync_nonce
-    store_write(:token, token) if @expose_token
+    if @expose_token
+      store_write(:token, token)
+      store_write(:refresh_token, refresh_token)
+    end
     store_write(:expires_at, Time.now.to_i + 3600 * 8)
 
     return_to = store_delete(:return_to) || '/'

--- a/test/expose_token_test.rb
+++ b/test/expose_token_test.rb
@@ -23,6 +23,7 @@ describe Heroku::Bouncer do
         follow_redirect!
 
         assert last_request.env['bouncer.token']
+        assert last_request.env['bouncer.refresh_token']
         assert_equal 'hi', last_response.body
       end
     end
@@ -48,6 +49,7 @@ describe Heroku::Bouncer do
         follow_redirect!
 
         assert last_request.env['bouncer.token'].nil?
+        assert last_request.env['bouncer.refresh_token'].nil?
         assert_equal 'hi', last_response.body
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,7 +55,7 @@ class MiniTest::Spec
 
   def follow_successful_oauth!(fetched_user_info = {})
     # /auth/heroku (OAuth dance starts)
-    OmniAuth.config.mock_auth[:heroku] = OmniAuth::AuthHash.new(provider: 'heroku', credentials: {token:'12345'})
+    OmniAuth.config.mock_auth[:heroku] = OmniAuth::AuthHash.new(provider: 'heroku', credentials: {token:'12345', refresh_token:'67890'})
     assert_equal "http://#{app_host}/auth/heroku", last_response.location, "The user didn't trigger the OmniAuth authentication"
     follow_redirect!
 


### PR DESCRIPTION
Passes `bouncer.refresh_token` from `heroku-oauth` so that fresh tokens can be obtained in the future.