### PR TITLE
Updated for Rails 5

### DIFF
--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_runtime_dependency("omniauth-heroku", "~> 0.1")
-  s.add_runtime_dependency("sinatra", "~> 1.0")
+  s.add_runtime_dependency("sinatra", ">= 1.0", "< 3")
   s.add_runtime_dependency("faraday", "~> 0.8")
-  s.add_runtime_dependency("rack", "~> 1.0")
+  s.add_runtime_dependency("rack", ">= 1.0", "< 3")
 
   s.add_development_dependency("rake", "~> 10.0")
   s.add_development_dependency("minitest", "~> 5.0")

--- a/lib/heroku/bouncer/lockbox.rb
+++ b/lib/heroku/bouncer/lockbox.rb
@@ -7,8 +7,8 @@ class Heroku::Bouncer::Lockbox < BasicObject
   end
 
   def lock(str)
-    aes = ::OpenSSL::Cipher::Cipher.new('aes-128-cbc').encrypt
-    aes.key = @key
+    aes = ::OpenSSL::Cipher::Cipher.new('aes-256-cbc').encrypt
+    aes.key = ::Base64.decode64(@key)
     iv = ::OpenSSL::Random.random_bytes(aes.iv_len)
     aes.iv = iv
     [iv + (aes.update(str) << aes.final)].pack('m0')
@@ -21,8 +21,8 @@ class Heroku::Bouncer::Lockbox < BasicObject
   # decrypt is too short to possibly be good aes data.
   def unlock(str)
     str = str.unpack('m0').first
-    aes = ::OpenSSL::Cipher::Cipher.new('aes-128-cbc').decrypt
-    aes.key = @key
+    aes = ::OpenSSL::Cipher::Cipher.new('aes-256-cbc').decrypt
+    aes.key = ::Base64.decode64(@key)
     iv = str[0, aes.iv_len]
     aes.iv = iv
     crypted_text = str[aes.iv_len..-1]

--- a/lib/heroku/bouncer/lockbox.rb
+++ b/lib/heroku/bouncer/lockbox.rb
@@ -8,7 +8,7 @@ class Heroku::Bouncer::Lockbox < BasicObject
 
   def lock(str)
     aes = ::OpenSSL::Cipher::Cipher.new('aes-256-cbc').encrypt
-    aes.key = ::Base64.decode64(@key)
+    aes.key = @key.size > 32 ? @key[0..31] : @key
     iv = ::OpenSSL::Random.random_bytes(aes.iv_len)
     aes.iv = iv
     [iv + (aes.update(str) << aes.final)].pack('m0')
@@ -22,7 +22,7 @@ class Heroku::Bouncer::Lockbox < BasicObject
   def unlock(str)
     str = str.unpack('m0').first
     aes = ::OpenSSL::Cipher::Cipher.new('aes-256-cbc').decrypt
-    aes.key = ::Base64.decode64(@key)
+    aes.key = @key.size > 32 ? @key[0..31] : @key
     iv = str[0, aes.iv_len]
     aes.iv = iv
     crypted_text = str[aes.iv_len..-1]

--- a/lib/heroku/bouncer/middleware.rb
+++ b/lib/heroku/bouncer/middleware.rb
@@ -20,7 +20,7 @@ class Heroku::Bouncer::Middleware < Sinatra::Base
       # super is not called; we're not using sinatra if we're disabled
     else
       super(app)
-      @cookie_secret = extract_option(options, :secret, SecureRandom.base64(32))
+      @cookie_secret = extract_option(options, :secret, SecureRandom.hex(64))
       @allow_if_user = extract_option(options, :allow_if_user, nil)
       @redirect_url = extract_option(options, :redirect_url, 'https://www.heroku.com')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ class MiniTest::Spec
     bouncer_config = default_bouncer_config
     bouncer_config.merge!(bouncer_config_block.call) if bouncer_config_block
     Sinatra.new do
-      use Rack::Session::Cookie, domain: MiniTest::Spec.app_host, secret: 'PTvbkXopkFHsRbphEqoi2pwqOFBGsfO7kVtZJ9XgEtQ='
+      use Rack::Session::Cookie, domain: MiniTest::Spec.app_host, secret: 'cde0e7ee63e9cb2edd04d8284961b28a6b6f6521f05d2094633dfbd00519fabaafae3b6ba3e92d9fe0770ea5a4f9a9e6be597cdcafbcfba12ea12b25508861fd'
       use Heroku::Bouncer, bouncer_config
       get '/:whatever' do
         params['whatever'] || 'root'
@@ -37,7 +37,7 @@ class MiniTest::Spec
   def default_bouncer_config
     {
       oauth: { id: '46307a2b-0397-4739-b2b7-2f67d1cff597', secret: '46307a2b-0397-4739-b2b7-2f67d1cff597' },
-      secret: 'PTvbkXopkFHsRbphEqoi2pwqOFBGsfO7kVtZJ9XgEtQ='
+      secret: 'cde0e7ee63e9cb2edd04d8284961b28a6b6f6521f05d2094633dfbd00519fabaafae3b6ba3e92d9fe0770ea5a4f9a9e6be597cdcafbcfba12ea12b25508861fd'
     }
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,9 +26,9 @@ class MiniTest::Spec
     bouncer_config = default_bouncer_config
     bouncer_config.merge!(bouncer_config_block.call) if bouncer_config_block
     Sinatra.new do
-      use Rack::Session::Cookie, domain: MiniTest::Spec.app_host, secret: 'guess-me'
+      use Rack::Session::Cookie, domain: MiniTest::Spec.app_host, secret: 'PTvbkXopkFHsRbphEqoi2pwqOFBGsfO7kVtZJ9XgEtQ='
       use Heroku::Bouncer, bouncer_config
-      get '/:whatever' do 
+      get '/:whatever' do
         params['whatever'] || 'root'
       end
     end
@@ -37,7 +37,7 @@ class MiniTest::Spec
   def default_bouncer_config
     {
       oauth: { id: '46307a2b-0397-4739-b2b7-2f67d1cff597', secret: '46307a2b-0397-4739-b2b7-2f67d1cff597' },
-      secret: 'bouncer-super-secret-ultra-secure-key'
+      secret: 'PTvbkXopkFHsRbphEqoi2pwqOFBGsfO7kVtZJ9XgEtQ='
     }
   end
 


### PR DESCRIPTION
Update the Sinatra and Rack dependencies to work with Rails 5.

I also needed to make some changes to the AES algorithm and key. These might be related to Ruby 2.4.0 (I'm not sure), but I think this is a good idea anyways.

In hindsight, I could go back to `aes-128-cbc` and use `key[0..16]`. But I think it might be best to use `aes-256-cbc`.